### PR TITLE
Format appwindow.slint

### DIFF
--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -1,12 +1,13 @@
 import { Button, VerticalBox } from "std-widgets.slint";
 
 export component AppWindow inherits Window {
-    in-out property<int> counter: 42;
+    in-out property <int> counter: 42;
     callback request-increase-value();
     VerticalBox {
         Text {
             text: "Counter: \{root.counter}";
         }
+
         Button {
             text: "Increase value";
             clicked => {


### PR DESCRIPTION
The recommended slint extension mildly reformats the appwindow.slint right after it has been generated. Not a big deal, but not smooth either