### PR TITLE
Get rid of console window on Windows.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+// Prevent console window in addition to Slint window in Windows release builds when, e.g., starting the app via file manager. Ignored on other platforms.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 slint::include_modules!();
 
 fn main() -> Result<(), slint::PlatformError> {


### PR DESCRIPTION
Without the `windows_subsystem` crate level attribute, starting the .exe, e.g., by double-clicking the file shows an empty console window before showing the Slint window. It's ignored on other platforms.

See <https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute>.