### PR TITLE
Removed unnecessary `Cargo.toml` `build` field.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
-build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
See <https://doc.rust-lang.org/cargo/reference/manifest.html#the-build-field>.

It was also tested to still work with `cargo clean; cargo run` in the PowerShell console in VS Code.