### PR TITLE
Use `anyhow::Result`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 // Prevent console window in addition to Slint window in Windows release builds when, e.g., starting the app via file manager. Ignored on other platforms.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::error::Error;
+
 slint::include_modules!();
 
-fn main() -> Result<(), slint::PlatformError> {
+fn main() -> Result<(), Box<dyn Error>> {
     let ui = AppWindow::new()?;
 
     ui.on_request_increase_value({
@@ -14,5 +16,7 @@ fn main() -> Result<(), slint::PlatformError> {
         }
     });
 
-    ui.run()
+    ui.run()?;
+
+    Ok(())
 }


### PR DESCRIPTION
See <https://crates.io/crates/anyhow#user-content-comparison-to-thiserror>.