### PR TITLE
Update precise Slint version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slint = "1.6"
+slint = "1.7.2"
 
 [build-dependencies]
-slint-build = "1.6"
+slint-build = "1.7.2"


### PR DESCRIPTION
Imprecise versions can get the downstream user an unintendedly old version. Set precedent using precise version.

See <https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277>.