### PR TITLE
Used `expect()` instead of `unwrap()` in `build.rs`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    slint_build::compile("ui/app-window.slint").unwrap();
+    slint_build::compile("ui/app-window.slint").expect("Slint build failed");
 }


### PR DESCRIPTION
See <https://github.com/slint-ui/slint/issues/6407>.