### PR TITLE
iOS: Make the default window contents look less awkward when resizing

### DIFF
--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -4,6 +4,7 @@ export component AppWindow inherits Window {
     in-out property <int> counter: 42;
     callback request-increase-value();
     VerticalBox {
+        alignment: start;
         Text {
             text: "Counter: \{root.counter}";
         }


### PR DESCRIPTION
On iOS the window is resized to the screen size. By adding the alignment the button won't be this huge blob.