### PR TITLE
Windows: Increase default stack size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,12 @@
 [target.x86_64-pc-windows-msvc]
-# Increase default stack size to match Linux
+# Increase default stack size to avoid running out of stack
+# space in debug builds. The size matches Linux's default.
 rustflags = [
-    "-C", "link-arg=/STACK:10000000"
+    "-C", "link-arg=/STACK:8000000"
 ]
 [target.aarch64-pc-windows-msvc]
-# Increase default stack size to match Linux
+# Increase default stack size to avoid running out of stack
+# space in debug builds. The size matches Linux's default.
 rustflags = [
-    "-C", "link-arg=/STACK:10000000"
+    "-C", "link-arg=/STACK:8000000"
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.x86_64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = [
+    "-C", "link-arg=/STACK:10000000"
+]
+[target.aarch64-pc-windows-msvc]
+# Increase default stack size to match Linux
+rustflags = [
+    "-C", "link-arg=/STACK:10000000"
+]


### PR DESCRIPTION
While not strictly required for this particular example, it's a better default for Rust development and good to get out of the way instead of running into it and then looking for this fix in the docs.

cc slint-ui/slint#4586