### PR TITLE
Update to Slint 1.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slint = "1.12.1"
+slint = "1.14.1"
 
 [build-dependencies]
-slint-build = "1.12.1"
+slint-build = "1.14.1"


### PR DESCRIPTION
This is the latest released version, and nothing special had to be changed for this update.