### PR TITLE
Update to Slint 1.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slint = "1.14.1"
+slint = "1.16.1"
 
 [build-dependencies]
-slint-build = "1.14.1"
+slint-build = "1.16.1"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Updated to the latest version on Crates.io right now.